### PR TITLE
feat(cors): www.makersround.world 오리진 추가

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -91,5 +91,5 @@ app.frontend.url=${FRONTEND_URL:http://localhost:5173}
 # ============================================
 # 허용할 Origin 목록 (쉼표로 구분)
 # 개발 환경: localhost
-# 실서비스: makersround.world
-app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173,https://makersround.world,http://makersround.world}
+# 실서비스: makersround.world, www.makersround.world
+app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173,https://makersround.world,http://makersround.world,https://www.makersround.world,http://www.makersround.world}


### PR DESCRIPTION
## 변경 사항 요약

이 PR은 CORS 허용 오리진에 `www.makersround.world`를 추가합니다.

### 주요 변경사항

**CORS 설정 업데이트:**
- `https://www.makersround.world` 추가
- `http://www.makersround.world` 추가
- 기존 `makersround.world` 오리진 유지
- 개발 환경 localhost 오리진 유지

### 영향

이 PR은 다음을 통해 프로덕션 배포 준비를 완료합니다:
- `makersround.world`와 `www.makersround.world` 모두 지원
- 서브도메인 변형에 대한 CORS 요청 허용

### 변경된 파일
- application.properties: CORS 오리진 설정 업데이트